### PR TITLE
Treat sphinx warnings as errors

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -W
 SPHINXBUILD   = python -msphinx
 SPHINXPROJ    = NarrativAPI
 SOURCEDIR     = .


### PR DESCRIPTION
Sphinx warnings are easily missed. This recently led to a few
regressions. Make sure all warnings are addressed before deploying the
documentation.